### PR TITLE
feat: ga event

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
   watchPlugins: ["jest-watch-typeahead/filename", "jest-watch-typeahead/testname"],
   testTimeout: 30000,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,6 +1979,12 @@
         "@types/node": "*"
       }
     },
+    "@types/gtag.js": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.10.tgz",
+      "integrity": "sha512-98Hy7woUb3jMAMXkZQwfIOYNyfxmI0+U4m0PpCGdnd/FHk0tDpQFCqgXdNkdEoXsKkcGya/2Gew1cAJjKJspVw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
-    "@ls-age/commitlint-circle": "^1.0.0",
     "@commitlint/config-conventional": "^15.0.0",
     "@commitlint/prompt": "^15.0.0",
+    "@ls-age/commitlint-circle": "^1.0.0",
+    "@types/gtag.js": "0.0.10",
     "@types/jest": "^27.0.3",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",

--- a/src/analytics/analytics.test.ts
+++ b/src/analytics/analytics.test.ts
@@ -1,0 +1,141 @@
+import { validatePageViewEvent, validateGaEvent, gaPageView, gaEvent } from "./Analytics";
+
+const consoleSpy = jest.spyOn(console, "error");
+const GA_MEASUREMENT_ID = "G-123456789";
+const mockGaEvent = {
+  action: "TEST_ACTION",
+  category: "TEST_CATEGORY",
+  label: "TEST_LABEL",
+  value: 2,
+};
+
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("validateGaPageView", () => {
+  it("throws if action is missing", () => {
+    // @ts-expect-error we expect this error to be thrown
+    validatePageViewEvent({});
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Action is required");
+  });
+});
+
+describe("gaPageView", () => {
+  beforeEach(() => {
+    window.gtag = jest.fn();
+  });
+
+  afterEach(() => {
+    // @ts-expect-error the mock does not match the signature
+    window.gtag = undefined;
+  });
+
+  it("sends and log gtag page view if window.gtag is present", () => {
+    gaPageView(
+      {
+        action: "TEST_ACTION",
+      } as any,
+      GA_MEASUREMENT_ID
+    );
+    expect(window.gtag).toBeCalledTimes(1);
+    expect(window.gtag).toHaveBeenCalledWith("event", "TEST_ACTION", {
+      send_to: GA_MEASUREMENT_ID,
+    });
+  });
+
+  it("throws if there is a validation error", () => {
+    const mockGaEventError = { action: 123 };
+    // @ts-expect-error the mock does not match the signature
+    gaPageView(mockGaEventError);
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Action must be a string");
+  });
+});
+
+describe("validateGaEvent", () => {
+  it("throws if category is missing", () => {
+    // @ts-expect-error we expect this error to be thrown
+    validateGaEvent({
+      action: "foobar_start",
+    });
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Category is required");
+  });
+
+  it("throws if action is missing", () => {
+    // @ts-expect-error we expect this error to be thrown
+    validateGaEvent({
+      category: "foobar",
+    });
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Action is required");
+  });
+
+  it("throws if value is not number", () => {
+    // @ts-expect-error we expect this error to be thrown
+    validateGaEvent({ category: "foobar", action: "foobar_start", value: "STRING" });
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Value must be a number");
+  });
+
+  it("passes for minimum values", () => {
+    validateGaEvent({
+      category: "foobar",
+      action: "foobar_start",
+      label: undefined,
+      value: undefined,
+    });
+    expect(true).toBe(true);
+  });
+
+  it("passes for all values", () => {
+    validateGaEvent({
+      category: "foobar",
+      action: "foobar_start",
+      label: "Start Foobar",
+      value: 2,
+    });
+    expect(true).toBe(true);
+  });
+});
+
+describe("gaEvent", () => {
+  beforeEach(() => {
+    window.gtag = jest.fn();
+  });
+
+  afterEach(() => {
+    // @ts-expect-error the mock does not match the signature
+    window.gtag = undefined;
+  });
+
+  it("does not fail if gtag is not present", () => {
+    gaEvent(mockGaEvent as any);
+    expect(true).toBe(true);
+  });
+
+  it("sends and log gtag event if window.gtag is present", () => {
+    gaEvent(mockGaEvent);
+    expect(window.gtag).toBeCalledTimes(1);
+    expect(window.gtag).toHaveBeenCalledWith("event", "TEST_ACTION", {
+      event_category: "TEST_CATEGORY",
+      event_label: "TEST_LABEL",
+      value: 2,
+    });
+  });
+
+  it("throws if there is a validation error", () => {
+    const mockGaEventError = { ...mockGaEvent, value: "STRING" };
+    // @ts-expect-error the mock does not match the signature
+    gaEvent(mockGaEventError);
+    expect(consoleSpy).toBeCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("Value must be a number");
+  });
+});

--- a/src/analytics/analytics.test.ts
+++ b/src/analytics/analytics.test.ts
@@ -1,4 +1,4 @@
-import { validatePageViewEvent, validateGaEvent, gaPageView, gaEvent } from "./Analytics";
+import { validatePageViewEvent, validateGaEvent, gaPageView, gaEvent } from "./analytics";
 
 const consoleSpy = jest.spyOn(console, "error");
 const GA_MEASUREMENT_ID = "G-123456789";

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -1,0 +1,45 @@
+type GaActionDefault = "page_view";
+
+interface GaEventProps {
+  action: string;
+  category: string;
+  label?: string;
+  value?: number;
+}
+
+interface GaPageViewProps {
+  action: GaActionDefault;
+}
+
+export const validatePageViewEvent = (gaEvent: GaPageViewProps): void => {
+  const { action } = gaEvent;
+  if (!action) console.error("Action is required");
+  if (action && typeof action !== "string") console.error("Action must be a string");
+};
+
+export const gaPageView = (gaEvent: GaPageViewProps, gaId: string): void => {
+  validatePageViewEvent(gaEvent);
+  const { action } = gaEvent;
+  gtag("event", action, {
+    send_to: gaId,
+  });
+};
+
+export const validateGaEvent = (gaEvent: GaEventProps): void => {
+  const { action, category, label, value } = gaEvent;
+  if (!category) console.error("Category is required");
+  if (!action) console.error("Action is required");
+  if (label && typeof label !== "string") console.error("Label must be a string");
+  if (value && typeof value !== "number") console.error("Value must be a number");
+};
+
+export const gaEvent = (gaEvent: GaEventProps): void => {
+  validateGaEvent(gaEvent);
+  const { action, category, label, value } = gaEvent;
+
+  gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from "./analytics";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import * as CONSTANTS from "./constants/VerificationErrorMessages";
-
+export * from "./analytics";
 export * from "./fragments";
 export { CONSTANTS };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es2016"],
+    "lib": ["es2016", "dom"],
     "target": "es5",
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
- shifting ga event tracking to here
- to remove and replace [here](https://github.com/TradeTrust/tradetrust-website/blob/master/src/common/analytics/Analytics.ts) after this release