### PR TITLE
fix: enhance interpretation of fragments

### DIFF
--- a/src/fragments/fragments.test.ts
+++ b/src/fragments/fragments.test.ts
@@ -6,7 +6,8 @@ import {
   whenDocumentValidAndIssuedByDns,
   whenDocumentValidAndIssuedByDid,
   whenDocumentHashInvalid,
-  whenDocumentRevoked,
+  whenDocumentIssuedAndRevokedByEthereumDocStore,
+  whenDocumentRevokedAndIdentifiedByDNSDID,
   whenDocumentIssuerIdentityInvalidDnsTxt,
   whenDocumentIssuerIdentityInvalidDid,
   whenTransferableDocumentVerified,
@@ -52,8 +53,15 @@ describe("interpretFragments", () => {
       identityValid: true,
     });
   });
-  it("should interpret whenDocumentRevoked correctly", () => {
-    expect(interpretFragments(whenDocumentRevoked as VerificationFragment[])).toEqual({
+  it("should interpret whenDocumentIssuedAndRevokedByEthereumDocStore correctly", () => {
+    expect(interpretFragments(whenDocumentIssuedAndRevokedByEthereumDocStore as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: false,
+      identityValid: true,
+    });
+  });
+  it("should interpret whenDocumentRevokedAndIdentifiedByDNSDID correctly", () => {
+    expect(interpretFragments(whenDocumentRevokedAndIdentifiedByDNSDID as VerificationFragment[])).toEqual({
       hashValid: true,
       issuedValid: false,
       identityValid: true,
@@ -101,8 +109,15 @@ describe("errorMessageHandling", () => {
     ]);
   });
 
-  it("should return revoked error when fragments indicate revoked", () => {
-    expect(errorMessageHandling(whenDocumentRevoked as VerificationFragment[])).toStrictEqual(["REVOKED"]);
+  it("should return revoked error when fragments indicate revoked (issued and revoked with ethereum doc store)", () => {
+    expect(
+      errorMessageHandling(whenDocumentIssuedAndRevokedByEthereumDocStore as VerificationFragment[])
+    ).toStrictEqual(["REVOKED"]);
+  });
+  it("should return revoked error when fragments indicate revoked (identified by DNS-DID but revoked with ethereum doc store)", () => {
+    expect(errorMessageHandling(whenDocumentRevokedAndIdentifiedByDNSDID as VerificationFragment[])).toStrictEqual([
+      "REVOKED",
+    ]);
   });
 
   it("should return invalid address error when fragments contain invalid address", () => {

--- a/src/fragments/fragments.test.ts
+++ b/src/fragments/fragments.test.ts
@@ -7,7 +7,7 @@ import {
   whenDocumentValidAndIssuedByDid,
   whenDocumentHashInvalid,
   whenDocumentIssuedAndRevokedByEthereumDocStore,
-  whenDocumentRevokedAndIdentifiedByDNSDID,
+  whenDocumentRevokedAndIdentifiedByDnsDid,
   whenDocumentIssuerIdentityInvalidDnsTxt,
   whenDocumentIssuerIdentityInvalidDid,
   whenTransferableDocumentVerified,
@@ -60,8 +60,8 @@ describe("interpretFragments", () => {
       identityValid: true,
     });
   });
-  it("should interpret whenDocumentRevokedAndIdentifiedByDNSDID correctly", () => {
-    expect(interpretFragments(whenDocumentRevokedAndIdentifiedByDNSDID as VerificationFragment[])).toEqual({
+  it("should interpret whenDocumentRevokedAndIdentifiedByDnsDid correctly", () => {
+    expect(interpretFragments(whenDocumentRevokedAndIdentifiedByDnsDid as VerificationFragment[])).toEqual({
       hashValid: true,
       issuedValid: false,
       identityValid: true,
@@ -115,7 +115,7 @@ describe("errorMessageHandling", () => {
     ).toStrictEqual(["REVOKED"]);
   });
   it("should return revoked error when fragments indicate revoked (identified by DNS-DID but revoked with ethereum doc store)", () => {
-    expect(errorMessageHandling(whenDocumentRevokedAndIdentifiedByDNSDID as VerificationFragment[])).toStrictEqual([
+    expect(errorMessageHandling(whenDocumentRevokedAndIdentifiedByDnsDid as VerificationFragment[])).toStrictEqual([
       "REVOKED",
     ]);
   });

--- a/src/fragments/fragments.ts
+++ b/src/fragments/fragments.ts
@@ -17,7 +17,7 @@ interface interpretFragmentsReturnTypes {
  * if we were to be thorough about making this change, would be better to include a new status code for  OpenAttestationDIDDocumentStoreStatusCode and expose a status code getter for it.
  * but the surface impact is huge, so opt to do it at the project level instead.
  */
-const certificateRevokedOnDIDIdentified = (fragments: VerificationFragment[]) => {
+const certificateRevokedOnDidIdentified = (fragments: VerificationFragment[]) => {
   const didSignedDocumentStatusFragment = utils.getOpenAttestationDidSignedDocumentStatusFragment(fragments);
   return (
     didSignedDocumentStatusFragment?.reason?.code === OpenAttestationEthereumDocumentStoreStatusCode.DOCUMENT_REVOKED
@@ -51,7 +51,7 @@ export const errorMessageHandling = (fragments: VerificationFragment[]): string[
   if (!hashValid) errors.push(TYPES.HASH);
   if (!identityValid) errors.push(TYPES.IDENTITY);
   if (!issuedValid) {
-    if (utils.certificateRevoked(fragments) || certificateRevokedOnDIDIdentified(fragments)) errors.push(TYPES.REVOKED);
+    if (utils.certificateRevoked(fragments) || certificateRevokedOnDidIdentified(fragments)) errors.push(TYPES.REVOKED);
     else if (utils.invalidArgument(fragments)) {
       // this error is caused when the merkle root is wrong, and should always be shown with the DOCUMENT_INTEGRITY error
       errors.push(TYPES.INVALID_ARGUMENT);

--- a/src/fragments/fragments.ts
+++ b/src/fragments/fragments.ts
@@ -1,4 +1,9 @@
-import { isValid, VerificationFragment, utils } from "@govtechsg/oa-verify";
+import {
+  isValid,
+  VerificationFragment,
+  utils,
+  OpenAttestationEthereumDocumentStoreStatusCode,
+} from "@govtechsg/oa-verify";
 import { TYPES } from "../constants/VerificationErrorMessages";
 
 interface interpretFragmentsReturnTypes {
@@ -6,6 +11,18 @@ interface interpretFragmentsReturnTypes {
   issuedValid: boolean;
   identityValid: boolean;
 }
+
+/** trying to make interpretation of the fragments for DIDSignedDocStoreRevokedDocuments
+ * currently certificateRevoked function from oa-verify does not handle it. (only checks the status codes for ethereumDocStoreVerifier)
+ * if we were to be thorough about making this change, would be better to include a new status code for  OpenAttestationDIDDocumentStoreStatusCode and expose a status code getter for it.
+ * but the surface impact is huge, so opt to do it at the project level instead.
+ */
+const certificateRevokedOnDIDIdentified = (fragments: VerificationFragment[]) => {
+  const didSignedDocumentStatusFragment = utils.getOpenAttestationDidSignedDocumentStatusFragment(fragments);
+  return (
+    didSignedDocumentStatusFragment?.reason?.code === OpenAttestationEthereumDocumentStoreStatusCode.DOCUMENT_REVOKED
+  );
+};
 
 export const interpretFragments = (fragments: VerificationFragment[]): interpretFragmentsReturnTypes => {
   const hashValid = isValid(fragments, ["DOCUMENT_INTEGRITY"]);
@@ -34,7 +51,7 @@ export const errorMessageHandling = (fragments: VerificationFragment[]): string[
   if (!hashValid) errors.push(TYPES.HASH);
   if (!identityValid) errors.push(TYPES.IDENTITY);
   if (!issuedValid) {
-    if (utils.certificateRevoked(fragments)) errors.push(TYPES.REVOKED);
+    if (utils.certificateRevoked(fragments) || certificateRevokedOnDIDIdentified(fragments)) errors.push(TYPES.REVOKED);
     else if (utils.invalidArgument(fragments)) {
       // this error is caused when the merkle root is wrong, and should always be shown with the DOCUMENT_INTEGRITY error
       errors.push(TYPES.INVALID_ARGUMENT);

--- a/src/test/fixtures/fragments/verifier-response.ts
+++ b/src/test/fixtures/fragments/verifier-response.ts
@@ -288,7 +288,7 @@ export const whenDocumentHashInvalid = [
   },
 ];
 
-export const whenDocumentRevokedAndIdentifiedByDNSDID = [
+export const whenDocumentRevokedAndIdentifiedByDnsDid = [
   {
     type: "DOCUMENT_INTEGRITY",
     name: "OpenAttestationHash",

--- a/src/test/fixtures/fragments/verifier-response.ts
+++ b/src/test/fixtures/fragments/verifier-response.ts
@@ -288,7 +288,93 @@ export const whenDocumentHashInvalid = [
   },
 ];
 
-export const whenDocumentRevoked = [
+export const whenDocumentRevokedAndIdentifiedByDNSDID = [
+  {
+    type: "DOCUMENT_INTEGRITY",
+    name: "OpenAttestationHash",
+    data: true,
+    status: "VALID",
+  },
+  {
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+    name: "OpenAttestationEthereumTokenRegistryStatus",
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "tokenRegistry" property or TOKEN_REGISTRY method',
+    },
+  },
+  {
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+    name: "OpenAttestationEthereumDocumentStoreStatus",
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "documentStore" or "certificateStore" property or DOCUMENT_STORE method',
+    },
+  },
+  {
+    name: "OpenAttestationDidSignedDocumentStatus",
+    type: "DOCUMENT_STATUS",
+    data: {
+      issuedOnAll: true,
+      revokedOnAny: true,
+      details: {
+        issuance: [
+          {
+            issued: true,
+            did: "did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733",
+          },
+        ],
+        revocation: [
+          {
+            revoked: true,
+            address: "0x49b2969bF0E4aa822023a9eA2293b24E4518C1DD",
+            reason: {
+              message:
+                "Document 0x3752f29527952e7ccc6bf4da614d80f2fec9e5bd8b71adf10beb4e6763e6c233 has been revoked under contract 0x49b2969bF0E4aa822023a9eA2293b24E4518C1DD",
+              code: 5,
+              codeString: "DOCUMENT_REVOKED",
+            },
+          },
+        ],
+      },
+    },
+    status: "INVALID",
+    reason: {
+      message:
+        "Document 0x3752f29527952e7ccc6bf4da614d80f2fec9e5bd8b71adf10beb4e6763e6c233 has been revoked under contract 0x49b2969bF0E4aa822023a9eA2293b24E4518C1DD",
+      code: 5,
+      codeString: "DOCUMENT_REVOKED",
+    },
+  },
+  {
+    status: "SKIPPED",
+    type: "ISSUER_IDENTITY",
+    name: "OpenAttestationDnsTxtIdentityProof",
+    reason: {
+      code: 2,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "documentStore" / "tokenRegistry" property or doesn\'t use DNS-TXT type',
+    },
+  },
+  {
+    name: "OpenAttestationDnsDidIdentityProof",
+    type: "ISSUER_IDENTITY",
+    data: [
+      {
+        location: "demo-tradetrust.openattestation.com",
+        key: "did:ethr:0x1245e5B64D785b25057f7438F715f4aA5D965733#controller",
+        status: "VALID",
+      },
+    ],
+    status: "VALID",
+  },
+];
+
+export const whenDocumentIssuedAndRevokedByEthereumDocStore = [
   {
     type: "DOCUMENT_INTEGRITY",
     name: "OpenAttestationHash",


### PR DESCRIPTION
## Summary
Recently it was discovered that our interpretation for certain variants of documents are not handled correctly.
Documents that are identified with a DID but revoked with an Ethereum Doc Store will be unhandled thus producing a generic error which might be confusing to the user. 
This pr enhances the interpretation of the fragments, by making the interpretation of revocation stricter by handling the `OpenAttestationDidSignedDocumentStatus` fragment. 

## Changes

- add new function that checks the `OpenAttestationDidSignedDocumentStatus` fragment
- add tests to test new functionality

## Issues
https://www.pivotaltracker.com/story/show/184277110