### PR TITLE
fix: dnsprove dep update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tradetrust-tt/tt-verify": "^8.8.4"
+        "@tradetrust-tt/tt-verify": "^8.9.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.6.1",
@@ -3642,16 +3642,24 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.0.tgz",
-      "integrity": "sha512-PoR66us8CJwi8LOeOWQjN7cNm1ezlmkZU6pmm7jWhmE2Z491a/hHCPaSL9o6C0uh/w49TLX7eyV/oo4jcB6tNw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.2.tgz",
+      "integrity": "sha512-PK2T7dlUZNgXxY6xl11OZACPUYXTDGhrg32H6aKAUMk/PUQ5BUcAlR7esMdl8uIxRuIxN04XGICBgvx/sAJSKQ==",
       "dependencies": {
-        "axios": "^1.6.3",
+        "axios": "0.21.1",
         "debug": "^4.3.1",
         "runtypes": "^6.3.0"
       },
       "engines": {
         "node": "18.x"
+      }
+    },
+    "node_modules/@tradetrust-tt/dnsprove/node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/@tradetrust-tt/document-store": {
@@ -3692,12 +3700,12 @@
       }
     },
     "node_modules/@tradetrust-tt/tt-verify": {
-      "version": "8.8.4",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-8.8.4.tgz",
-      "integrity": "sha512-euF33xwutC1LRiD2bY2Sorh0DEeWHAlV2476+HqSPWTus0WVhcLtWa+AfE56y/93NpfKvucfRzYMjHihc1FhqA==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-8.9.1.tgz",
+      "integrity": "sha512-odgmL5K46HanqrS18KcI4NH0FsGVW/3ofuhB44Xm8AP6Te69ejoJdIPKZBmjWtvTElcXDyfuNnV+gTbMfMSEgg==",
       "dependencies": {
         "@govtechsg/oa-did-sign": "^2.2.0",
-        "@tradetrust-tt/dnsprove": "^2.12.0",
+        "@tradetrust-tt/dnsprove": "^2.12.2",
         "@tradetrust-tt/document-store": "^2.7.0",
         "@tradetrust-tt/token-registry": "^4.9.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -4906,11 +4914,11 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -7816,9 +7824,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tradetrust-tt/tt-verify": "^8.8.4"
+    "@tradetrust-tt/tt-verify": "^8.9.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",


### PR DESCRIPTION
## Summary

update tt-verify to latest vesrion as upstream dep dnsprove is updated
