### PR TITLE
chore: change stability rpc url

### DIFF
--- a/src/constants/supportedChains.ts
+++ b/src/constants/supportedChains.ts
@@ -202,7 +202,7 @@ export const SUPPORTED_CHAINS: supportedChains = {
     currency: "FREE",
     iconImage: iconStability,
     explorerUrl: "https://stability.blockscout.com/",
-    rpcUrl: `https://gtn.stabilityprotocol.com/?api_key=${process.env.STABILITY_API_KEY}`,
+    rpcUrl: `https://gtn.stabilityprotocol.com/zgt/${process.env.STABILITY_API_KEY}`,
     nativeCurrency: {
       name: "FREE",
       symbol: "FREE",


### PR DESCRIPTION
# Summary
This PR changes the URL format of the [Stability GTN](https://github.com/stabilityprotocol/) RPC.

# Changes
- Change the URL of the  Stability GTN RPC

# Issues
NA

