### PR TITLE
Updated archive RPC for XDC

### DIFF
--- a/src/constants/supportedChains.ts
+++ b/src/constants/supportedChains.ts
@@ -110,7 +110,7 @@ export const SUPPORTED_CHAINS: supportedChains = {
     currency: "XDC",
     iconImage: iconXDC,
     explorerUrl: "https://xdcscan.io",
-    rpcUrl: "https://rpc.ankr.com/xdc",
+    rpcUrl: "https://tradetrustrpc.xdcrpc.com",
     nativeCurrency: {
       name: "XDC",
       symbol: "XDC",
@@ -125,7 +125,7 @@ export const SUPPORTED_CHAINS: supportedChains = {
     currency: "XDC",
     iconImage: iconXDC,
     explorerUrl: "https://apothem.xdcscan.io",
-    rpcUrl: "https://rpc.ankr.com/xdc_testnet",
+    rpcUrl: "https://tradetrustarpc.xdcrpc.com",
     nativeCurrency: {
       name: "XDC",
       symbol: "XDC",


### PR DESCRIPTION
What is the background of this pull request?
Change the RPC after setting up a dedicated loadbalance archival RPC on Mainnet and Testnet for TradeTrust to prevent future RPC issues. This archival RPC will include load balancing and will be connected to multiple RPC providers to ensure maximum uptime.

Changes
Updated the configuration files containing RPC URLs.
<img width="675" alt="image" src="https://github.com/TradeTrust/tradetrust-utils/assets/39335466/ee318a11-7a36-496b-a11d-2b7526aea9f5">

Issues
View endorsement chain during verification of document fails as it requires archival node to fetch complete history