### PR TITLE
fix: package dep for dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tradetrust-tt/tt-verify": "^9.2.0"
+        "@tradetrust-tt/tt-verify": "^9.2.0",
+        "dotenv": "^16.4.5"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.6.1",
@@ -19,7 +20,6 @@
         "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
-        "dotenv": "^16.4.5",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
@@ -6068,7 +6068,6 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tradetrust-tt/tt-verify": "^9.2.0"
+    "@tradetrust-tt/tt-verify": "^9.2.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",
@@ -73,7 +74,6 @@
     "@types/jest": "^29.5.12",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
-    "dotenv": "^16.4.5",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- dotenv is imported in code, should not be in dev dependency.
- Resulted in error during build https://github.com/TradeTrust/tradetrust-decentralized-renderer/actions/runs/12629531671/job/35187620818